### PR TITLE
use glsl 3.0 programs throughout - closes #81 closes #62

### DIFF
--- a/src/knn_util.ts
+++ b/src/knn_util.ts
@@ -655,16 +655,17 @@ export function executeKNNProgram(
 export function createCopyDistancesProgram(
   gpgpu: tf.webgl.GPGPUContext
 ): WebGLProgram {
-  const fragmentShaderSource = `
+  const fragmentShaderSource = `#version 300 es
     precision highp float;
     uniform sampler2D knn_tex;
     uniform float width;
     uniform float height;
 
+    out vec4 fragColor;
     void main() {
       vec2 coordinates = gl_FragCoord.xy / vec2(width,height);
-      float distance = texture2D(knn_tex,coordinates).g;
-      gl_FragColor = vec4(distance,0,0,1);
+      float distance = texture(knn_tex, coordinates).g;
+      fragColor = vec4(distance, 0, 0, 1);
     }
   `
   return gpgpu.createProgram(fragmentShaderSource)
@@ -723,19 +724,20 @@ export function executeCopyDistancesProgram(
 export function createCopyIndicesProgram(
   gpgpu: tf.webgl.GPGPUContext
 ): WebGLProgram {
-  const fragmentShaderSource = `
+  const fragmentShaderSource = `#version 300 es
     precision highp float;
     uniform sampler2D knn_tex;
     uniform float width;
     uniform float height;
 
+    out vec4 fragColor;
     void main() {
       vec2 coordinates = gl_FragCoord.xy / vec2(width,height);
-      float id = texture2D(knn_tex,coordinates).r;
-      gl_FragColor = vec4(id,0,0,1);
+      float id = texture(knn_tex, coordinates).r;
+      fragColor = vec4(id,0,0,1);
 
-      if(id < 0.) {
-        gl_FragColor.b = 1.;
+      if (id < 0.) {
+        fragColor.b = 1.;
       }
     }
   `


### PR DESCRIPTION
This is really great work! I wanted to send along a little PR that resolves the shader linking problem. Here I just set some declarations to move all glsl programs to glsl 3.0, which allows the shaders to compile and allows the demos to run:

<img width="890" alt="Screen Shot 2020-04-29 at 5 18 25 PM" src="https://user-images.githubusercontent.com/4801116/80649326-cd4a6900-8a3f-11ea-9bd2-69af24a360a3.png">

I also had to change a few function calls as some of the built in functions changed in glsl 3.0. I'm happy to make any changes you see fit!